### PR TITLE
Cache bundler and don't use bundler 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,7 @@ cache: bundler
 before_install:
   - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
   - gem install bundler -v '< 2'
+  - psql -c 'create database travis_ci_test;' -U postgres
+  - cp config/database.yml.travis config/database.yml
 rvm:
   - 2.5.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,5 @@ before_install:
   - cp config/database.yml.travis config/database.yml
 rvm:
   - 2.5.3
+addons:
+  postgresql: "9.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
 language: ruby
+cache: bundler
+before_install:
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'
 rvm:
-  - 2.5
+  - 2.5.3

--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem 'ruby-progressbar'
 gem 'kaminari-activerecord'
 
 # For efficient monitoring of Windows directory changes
-gem 'wdm', '>= 0.1.0' if Gem.win_platform?
+gem 'wdm', '>= 0.1.0', :platforms => [:x64_mingw]
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/config/database.yml.travis
+++ b/config/database.yml.travis
@@ -1,0 +1,3 @@
+test:
+  adapter: postgresql
+  database: travis_ci_test

--- a/spec/models/deck_card_spec.rb
+++ b/spec/models/deck_card_spec.rb
@@ -10,6 +10,6 @@ RSpec.describe DeckCard, type: :model do
 
   context "card uniqueness" do
     subject { FactoryBot.create(:deck_card, :with_persisted_card) }
-    it { is_expected.to validate_uniqueness_of(:card_id).scoped_to(:deck_id) }
+    it { is_expected.to validate_uniqueness_of(:card_id).scoped_to(:deck_id, :mainboard) }
   end
 end


### PR DESCRIPTION
Bundler 2 causes the build to fail, so uninstall it and install bundler < 2. Also cache bundler so subsequent runs are faster.