### PR TITLE
Fix development problems and a card list error

### DIFF
--- a/app/views/api/v1/mtg_cards/show.json.jbuilder
+++ b/app/views/api/v1/mtg_cards/show.json.jbuilder
@@ -8,7 +8,7 @@ json.art @card.image_uris&.fetch('art_crop', nil) || @card.card_faces&.dig(0, 'i
 json.mana_cost @card.mana_cost
 json.cmc @card.cmc
 json.card_type @card.type_line
-json.card_text @card.oracle_text.gsub(/\n/, '\\\n')
+json.card_text @card.oracle_text&.gsub(/\n/, '\\\n')
 json.power @card.power
 json.toughness @card.toughness
 json.colors @card.colors

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -21,17 +21,20 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-workers ENV.fetch("WEB_CONCURRENCY") { 2 }
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code
 # before forking the application. This takes advantage of Copy On Write
 # process behavior so workers use less memory.
 #
-preload_app!
 
-on_worker_boot do
-  ActiveRecord::Base.establish_connection
+if ENV['RAILS_ENV'] == 'production'
+  workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+  preload_app!
+
+  on_worker_boot do
+    ActiveRecord::Base.establish_connection
+  end
 end
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart


### PR DESCRIPTION
### Problem

1. Card list was blowing up if oracle text is nil
1. Windows can't use Puma workers

### Solution

1. Put a safe operator on the oracle text before trying to gsub it
1. Only use Puma workers in production